### PR TITLE
Merge develop into master for update

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+# Contributing to YFPP
+Thanks for considering contributing to YFPP. We're still determining our contributing guidelines and open source license, so, until we do, this project is only open to the existing contributors. Follow this project for updates.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior


### PR DESCRIPTION
This is a non-deploy merge. For the contributing and issue templates to work, they have to be in the default branch (i.e. `master` in this case).