### PR TITLE
Feature/map directions updates

### DIFF
--- a/src/components/LocationCard/LocationCard.js
+++ b/src/components/LocationCard/LocationCard.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import classnames from 'classnames';
@@ -12,6 +12,7 @@ import Map from 'components/Map/Map';
 import { CloseIcon } from 'components/Icons';
 import { motion } from 'framer-motion';
 import useOutsideClick from 'hooks/useOutsideClick';
+import { AppContext } from 'appReducer';
 
 const LocationCard = ({ data, locationType, slug }) => {
     const {
@@ -27,6 +28,8 @@ const LocationCard = ({ data, locationType, slug }) => {
     const locationCardRef = useRef();
 
     useOutsideClick(locationCardRef, handleCloseMap);
+    const { normalizedAddress } = useContext(AppContext);
+
     const openSpring = { type: 'spring', stiffness: 200, damping: 30 };
     const closeSpring = { type: 'spring', stiffness: 300, damping: 35 };
 
@@ -111,7 +114,14 @@ const LocationCard = ({ data, locationType, slug }) => {
                 </div>
                 {isActive && (
                     <motion.div className="locationCard__map" layout>
-                        <Map latitude={latitude} longitude={longitude} />
+                        <Map
+                            latitude={latitude}
+                            longitude={longitude}
+                            originAddress={normalizedAddress}
+                            destinationAddress={Object.values(address).join(
+                                ' '
+                            )}
+                        />
                     </motion.div>
                 )}
                 <motion.div className="locationCard__ft" layout>

--- a/src/components/LocationCard/LocationCard.js
+++ b/src/components/LocationCard/LocationCard.js
@@ -117,9 +117,11 @@ const LocationCard = ({ data, locationType, slug }) => {
                         <Map
                             latitude={latitude}
                             longitude={longitude}
-                            originAddress={normalizedAddress}
-                            destinationAddress={Object.values(address).join(
-                                ' '
+                            originAddress={helpers.getAddressStringFromObject(
+                                normalizedAddress
+                            )}
+                            destinationAddress={helpers.getAddressStringFromObject(
+                                address
                             )}
                         />
                     </motion.div>

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -5,7 +5,7 @@ import './map.scss';
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_API_ACCESS_TOKEN;
 
-const Map = ({ latitude, longitude }) => {
+const Map = ({ latitude, longitude, originAddress, destinationAddress }) => {
     const mapContainerRef = useRef(null);
 
     const [lng, setLng] = useState(longitude);
@@ -25,8 +25,8 @@ const Map = ({ latitude, longitude }) => {
             accessToken: mapboxgl.accessToken,
             geocoder: {
                 countries: ['US'],
-                proximity: [lng, lat]
-            }
+                proximity: [lng, lat],
+            },
         });
 
         // Add navigation control (the +/- zoom buttons)
@@ -43,7 +43,8 @@ const Map = ({ latitude, longitude }) => {
         });
 
         map.on('load', () => {
-            directions.setDestination([lng, lat]);
+            directions.setOrigin(Object.values(originAddress).join(' '));
+            directions.setDestination(destinationAddress);
         });
 
         // Clean up on unmount

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -38,8 +38,6 @@ const Map = ({ latitude, longitude, originAddress, destinationAddress }) => {
         // to the directions inputs on the map because they only
         // seem to get populated with origin/destination strings
         // one time on page load even though our Map component is mounting and unmounting
-        let originInput = null;
-        let destinationInput = null;
 
         map.on('move', () => {
             setLng(map.getCenter().lng.toFixed(4));
@@ -82,8 +80,6 @@ const Map = ({ latitude, longitude, originAddress, destinationAddress }) => {
             map = null;
             directions = null;
             navControl = null;
-            originInput = null;
-            destinationInput = null;
         };
     }, [originAddress, destinationAddress]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/Map/map.scss
+++ b/src/components/Map/map.scss
@@ -9,7 +9,7 @@
 // mapbox overrides
 .mapboxgl-ctrl-top-left {
     height: 100%;
-    padding-bottom: 25px; // leave space for mapbox logo
+    padding-bottom: 45px; // leave space for mapbox logo
 }
 
 .mapboxgl-ctrl-top-left .mapboxgl-ctrl {

--- a/src/components/Map/map.scss
+++ b/src/components/Map/map.scss
@@ -5,3 +5,28 @@
     left: 0;
     right: 0;
 }
+
+// mapbox overrides
+.mapboxgl-ctrl-top-left {
+    height: 100%;
+    padding-bottom: 25px; // leave space for mapbox logo
+}
+
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl {
+    float: none;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.directions-control {
+    overflow: auto;
+}
+
+.directions-control-inputs {
+    flex: 1 0 auto;
+}
+
+.mapbox-directions-step {
+    font-weight: normal;
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,10 @@
 import useQuery from 'hooks/useQuery';
 // global helper functions
 const isDevelopmentMode = useQuery().get('development');
-const API_DEV_VOTER_INFO_URL = process.env.PUBLIC_URL + process.env.REACT_APP_API_DEV_VOTER_INFO_URL;
-const API_DEV_REPRESENTATIVES_URL = process.env.PUBLIC_URL + process.env.REACT_APP_API_DEV_REPRESENTATIVES_URL;
+const API_DEV_VOTER_INFO_URL =
+    process.env.PUBLIC_URL + process.env.REACT_APP_API_DEV_VOTER_INFO_URL;
+const API_DEV_REPRESENTATIVES_URL =
+    process.env.PUBLIC_URL + process.env.REACT_APP_API_DEV_REPRESENTATIVES_URL;
 const API_URL = process.env.REACT_APP_API_URL;
 
 let helpers = {
@@ -13,7 +15,7 @@ let helpers = {
      * @method concatStreetAddress
      * @return {string} concatenated address or empty string
      */
-    concatStreetAddress: function (obj) {
+    concatStreetAddress: function(obj) {
         var addr = [obj.line1 || '', obj.line2 || '', obj.line3 || ''],
             addr_str = '',
             city = obj.city || '',
@@ -34,7 +36,7 @@ let helpers = {
         return address;
     },
 
-    lowerCase: function (string) {
+    lowerCase: function(string) {
         if (string) {
             return string.toLowerCase();
         }
@@ -46,13 +48,16 @@ let helpers = {
      * @method fucktify
      * @return {string} unsanitized phrase
      */
-    fucktify: function (str) {
+    fucktify: function(str) {
         if (str === undefined) {
             str = 'Some fucking building';
         } else {
             // I need to standardize the character case because
             // the data is chaos and indexOf uses strict equality
-            var str_arr = String(str).toLowerCase().trim().split(' ');
+            var str_arr = String(str)
+                .toLowerCase()
+                .trim()
+                .split(' ');
             // assuming two or more words...
             if (str_arr.length >= 2) {
                 // ...check for the existence/index of "of"...
@@ -81,12 +86,14 @@ let helpers = {
      * @method cleanString
      * @return {string} cleaned string
      */
-    cleanString: function (str) {
+    cleanString: function(str) {
         // underscores in names and multiple spaces between words
         var charactersRegex = /_/g,
             multipleSpaces = /\s\s+/g;
 
-        return str && str.replace(charactersRegex, '').replace(multipleSpaces, ' ');
+        return (
+            str && str.replace(charactersRegex, '').replace(multipleSpaces, ' ')
+        );
     },
 
     /**
@@ -95,7 +102,7 @@ let helpers = {
      * @method titlecase
      * @return {string} titlecased string
      */
-    titlecase: function (str) {
+    titlecase: function(str) {
         var words = '';
 
         // apparently there are situations where the array
@@ -104,7 +111,10 @@ let helpers = {
         str = this.cleanString(str);
 
         if (str) {
-            words = str.toLowerCase().trim().split(' ');
+            words = str
+                .toLowerCase()
+                .trim()
+                .split(' ');
             for (var i = 0; i < words.length; i++) {
                 var letters = words[i].split('');
                 letters[0] = letters[0].toUpperCase();
@@ -122,7 +132,7 @@ let helpers = {
      * @method shuffle
      * @return {array} randomized array
      */
-    shuffle: function (array) {
+    shuffle: function(array) {
         var currentIndex = array.length,
             temporaryValue,
             randomIndex;
@@ -138,10 +148,14 @@ let helpers = {
         }
         return array;
     },
-    buildQueryString: function (params) {
+    buildQueryString: function(params) {
         return Object.keys(params)
-            .map((key) => {
-                return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+            .map(key => {
+                return (
+                    encodeURIComponent(key) +
+                    '=' +
+                    encodeURIComponent(params[key])
+                );
             })
             .join('&');
     },
@@ -156,9 +170,9 @@ let helpers = {
             .replace(/^-+/, '')
             .replace(/-+$/, '');
     },
-    getRequestURL: function (route, requestParams) {
+    getRequestURL: function(route, requestParams) {
         const baseParams = {
-            key: process.env.REACT_APP_API_KEY
+            key: process.env.REACT_APP_API_KEY,
         };
 
         if (process.env.NODE_ENV === 'development' && isDevelopmentMode) {
@@ -170,8 +184,14 @@ let helpers = {
             }
         }
 
-        return `${API_URL}/${route}?${helpers.buildQueryString({...baseParams, ...requestParams})}`;
-    }
+        return `${API_URL}/${route}?${helpers.buildQueryString({
+            ...baseParams,
+            ...requestParams,
+        })}`;
+    },
+    getAddressStringFromObject: function({ line1, line2, city, state, zip }) {
+        return `${line1} ${line2 ? line2 : ''} ${city} ${state} ${zip}`;
+    },
 };
 
 export default helpers;


### PR DESCRIPTION
The directions plugin for mapBox doesn't seem to be updating the input values for the origin and destination fields after the initial page render. It works for the first map, but subsequent map openings result in empty inputs for the direction fields.

As a work-around, added some imperative code inside the on load handler for the map to fill the inputs in if the function calls don't do their job.