### PR TITLE
Use corepack install --global for pnpm availability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,10 @@ jobs:
           node-version: 22
 
       - name: Enable Corepack and install pnpm
-        run: corepack enable && corepack install
+        run: |
+          corepack enable
+          corepack install --global
+          pnpm --version
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:


### PR DESCRIPTION
corepack install without --global creates a project-local installation that isn't on PATH for subsequent steps.