### PR TITLE
Disable setup-node auto-caching to avoid pnpm detection error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Enable Corepack and install pnpm
         run: |


### PR DESCRIPTION
setup-node v5 auto-detects packageManager in package.json and tries to find pnpm for caching before corepack has been enabled. Disable with package-manager-cache: false since we use actions/cache separately.