### PR TITLE
Use corepack install without --global flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Enable Corepack and install pnpm
         run: |
           corepack enable
-          corepack install --global
+          corepack install
           pnpm --version
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
corepack install (without --global) reads packageManager from package.json. The --global flag requires an explicit package manager argument and doesn't auto-detect from the project.