### PR TITLE
Add helpers and update tsconfig target to ES2024

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "ES2024",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
       "appReducer": ["./src/appReducer"],
       "components/*": ["./src/components/*"],
       "helpers": ["./src/helpers"],
+      "helpers/*": ["./src/helpers/*"],
       "hooks/*": ["./src/hooks/*"],
       "images/*": ["./src/images/*"],
       "requests/*": ["./src/requests/*"],


### PR DESCRIPTION
- The helpers directory now contains submodules (e.g., getResultsRoute) imported as helpers/getResultsRoute. The existing helpers path alias only mapped the directory root, not subpaths.
- Node 22 (CI runtime) fully supports ES2024. This enables new type definitions, such as array grouping, Promise.withResolvers, etc.