### PR TITLE
Resolve pnpm store path dynamically for CI cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,13 @@ jobs:
           corepack install
           pnpm --version
 
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: ~/.local/share/pnpm/store/v3
+          path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-store-
 


### PR DESCRIPTION
The hardcoded ~/.local/share/pnpm/store/v3 doesn't match where corepack-installed pnpm places its store. Use pnpm store path to resolve it at runtime.